### PR TITLE
Fixed bug where snackbar doesn't show after selecting 'Don't ask again' on a permission

### DIFF
--- a/RuntimePermissionsBasicKotlin/Application/src/main/java/com/example/android/basicpermissions/util/ViewExt.kt
+++ b/RuntimePermissionsBasicKotlin/Application/src/main/java/com/example/android/basicpermissions/util/ViewExt.kt
@@ -37,15 +37,13 @@ fun View.showSnackbar(
 }
 
 fun View.showSnackbar(
-        msg: String,
-        length: Int,
-        actionMessage: CharSequence?,
-        action: (View) -> Unit
+        msg: String, length: Int, actionMessage: CharSequence?, action: (View) -> Unit
 ) {
     val snackbar = Snackbar.make(this, msg, length)
-    if (actionMessage != null) {
-        snackbar.setAction(actionMessage) {
+    actionMessage?.let {
+        snackbar.setAction(it) {
             action(this)
-        }.show()
+        }
     }
+    snackbar.show()
 }


### PR DESCRIPTION
Fixed bug where snacker doesn't show after selecting 'Don't ask again on permission'