### PR TITLE
Make sure that shows() function is executed at the end

### DIFF
--- a/RuntimePermissionsBasicKotlin/Application/src/main/java/com/example/android/basicpermissions/util/ViewExt.kt
+++ b/RuntimePermissionsBasicKotlin/Application/src/main/java/com/example/android/basicpermissions/util/ViewExt.kt
@@ -46,6 +46,7 @@ fun View.showSnackbar(
     if (actionMessage != null) {
         snackbar.setAction(actionMessage) {
             action(this)
-        }.show()
+        }
     }
+    snackbar.show()
 }


### PR DESCRIPTION
Fixes the bug where snackbars don't show as described in https://stackoverflow.com/questions/76135698/function-extension-of-snackbar-does-not-work-in-fragment.